### PR TITLE
Fix for empty query strings. Fixes #2

### DIFF
--- a/qp.js
+++ b/qp.js
@@ -6,5 +6,5 @@
  */
 
 window.getQueryParameters = function(str) {
-  return (str || document.location.search).replace(/(^\?)/,'').split("&").reduce(function(o,n){n=n.split('=');o[n[0]]=n[1];return o},{});
+  return (str || document.location.search).replace(/(^\?)/,'').split("&").filter(Boolean).reduce(function(o,n){n=n.split('=');o[n[0]]=n[1];return o},{});
 }


### PR DESCRIPTION
This one-liner fix requires [Array.filter](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/filter), which is not available on IE <= 8.
